### PR TITLE
dev_mp_77

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@
 
 ### Uwaga
 
-Warunkiem koniecznym do prawidłowego działania wtyczki jest posiadanie wersji QGIS 3.16.16 lub wyższej.
+Warunkiem koniecznym do prawidłowego działania wtyczki jest posiadanie wersji QGIS QGIS 3.28.0 lub wyższej.
 
-
+Rekomendowane wersje QGIS: 3.34.5.
 
 # ULDK
 
@@ -82,4 +82,6 @@ The plugin offers 3 methods for searching and downloading boundaries.
 In the side panel, there are options to select the area of interest (parcel, registration area, municipality, county, voivodeship). If you want to download the voivodeship layer where your parcel is located, select "Województwo" in the side panel. Once you enter the parcel identifier, the plugin will automatically download the associated voivodeship or another selected area. If the parcel number appears more than once in the same registration area, a message will appear at the top of QGIS, and the plugin will download the first parcel returned by the ULDK service.
 
 ### Note
-A necessary condition for the plugin to work correctly is having QGIS version 3.16.16 or higher."
+A necessary condition for the plugin to work correctly is having QGIS version 3.28.0 or higher."
+
+Recomended version of QGIS: 3.45.5. 

--- a/ui/uldk_gugik_dialog_base.ui
+++ b/ui/uldk_gugik_dialog_base.ui
@@ -898,7 +898,7 @@
            </font>
           </property>
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;© 2024 &lt;a href=&quot;http://www.envirosolutions.pl/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;EnviroSolutions Sp. z o.o.&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;© 2025 &lt;a href=&quot;http://www.envirosolutions.pl/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;EnviroSolutions Sp. z o.o.&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="textFormat">
            <enum>Qt::RichText</enum>

--- a/uldk_gugik.py
+++ b/uldk_gugik.py
@@ -8,7 +8,7 @@
                               -------------------
         begin                : 2019-05-31
         git sha              : $Format:%H$
-        copyright            : (C) 2019 by EnviroSolutions Sp. z o.o.
+        copyright            : (C) 2025 by EnviroSolutions Sp. z o.o.
         email                : office@envirosolutions.pl
  ***************************************************************************/
 
@@ -43,7 +43,7 @@ from .constants import DEFAULT_SRID
 
 
 """Wersja wtyczki"""
-plugin_version = '1.4.1'
+plugin_version = '1.4.2'
 plugin_name = 'ULDK GUGiK'  
 
 class UldkGugik:


### PR DESCRIPTION
- zmień wersje wtyczek w metadanych i głównym kodzie w parametrze version
- zmień w metadanych minimalna wersję qgis na 3.28 lub wyższa w zależności czy na 3.28 działa wtyczka w ogóle
- ustaw copyright na 2025 r.
- W readme wpisz rekomendowana przez nas wersję QGIS do odpalenia wtyczki w formacie X.XX.XX